### PR TITLE
Should fix the https unsafe scripts problem

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ words_per_minute: 800
 # When testing locally leave blank or use http://localhost:4000
 
 # url: # comment this when pushing to server
-url: http://tupleblog.github.io # comment this when testing locally
+url: //tupleblog.github.io # comment this when testing locally
 
 # Owner/author information
 owner:


### PR DESCRIPTION
Mixed Content: The page at 'https://tupleblog.github.io/spotify/' was loaded over HTTPS, but requested an insecure stylesheet 'http://tupleblog.github.io/assets/css/main.css'. This request has been blocked; the content must be served over HTTPS.

I think this will fix it. This is not tested.